### PR TITLE
Fix forms page typos

### DIFF
--- a/source/guides/saving-with-forms.html.md.erb
+++ b/source/guides/saving-with-forms.html.md.erb
@@ -21,7 +21,7 @@ guide][/guides/querying-the-database.html]. Once you have that set up, let’s s
 up a form:
 
 ```
-# src/queries/user_form.cr
+# src/forms/user_form.cr
 class UserForm < User::BaseForm
 end
 ```

--- a/source/guides/saving-with-forms.html.md.erb
+++ b/source/guides/saving-with-forms.html.md.erb
@@ -17,7 +17,7 @@ from it and customize validations, callbacks, and what fields are allowed to be
 set.
 
 We’ll be using the migration and model from the [Querying
-guide][/guides/querying-the-database.html]. Once you have that set up, let’s set
+guide](/guides/querying-the-database/). Once you have that set up, let’s set
 up a form:
 
 ```


### PR DESCRIPTION
- Changes the file location comment for `user_form.cr` to use the correct path `src/forms` instead of `src/queries`
- Fixes the link syntax to the querying the database page (and use the pretty URL)