### PR TITLE
Add clarification to the origin of form fields

### DIFF
--- a/source/guides/saving-with-forms.html.md.erb
+++ b/source/guides/saving-with-forms.html.md.erb
@@ -14,7 +14,7 @@ maintainability, and catching bugs at compile time.
 
 When you set up a model, a `{ModelName}::BaseForm` will be created so that you can inherit
 from it and customize validations, callbacks, and what fields are allowed to be
-set.
+set. `{ModelName}::BaseForm` automatically defines a form field for each model field.
 
 We’ll be using the migration and model from the [Querying
 guide](/guides/querying-the-database/). Once you have that set up, let’s set


### PR DESCRIPTION
As discussed in gitter:
```
Hannes Käufler @hanneskaeufler 21:56
Ah yeah sorry to confuse, the first quote is to give context where I'm pointing at 
That one was my suggestion of what could be added:
This {ModelName}::BaseForm automatically has a field for each of the model fields
but actually the first sentence is missing a and what fields are ALLOWED to be set?

Paul Smith @paulcsmith 21:57
Oh I see. Yeah that's a good idea. And maybe an example like the one for slug would be good. I'll create an issue for it!
Or you could open a PR with that change so we can discuss it 

Hannes Käufler @hanneskaeufler 21:58
I will!

Paul Smith @paulcsmith 21:58
Awesome! Thanks

Edward Loveall @edwardloveall 21:58
{ModelName}::BaseForm automatically adds a field for each model attribute.
maybe

Paul Smith @paulcsmith 22:00
I like that 
I think writing a tutorial that goes through building a sample app would also be helpful. I want to do that at some point
```