### PR TITLE
Separate Conjoined E's.

### DIFF
--- a/source/guides/saving-with-forms.html.md.erb
+++ b/source/guides/saving-with-forms.html.md.erb
@@ -408,7 +408,7 @@ breaking other flows.
 Here are some ideas for naming:
 
 * `Csv{ModelName}Form` - great for forms that get data from a CSV. e.g. `CsvUserImportForm`
-* `SignUpForm` - for signing up a new user. Encrypt passwords, send welcom eemails, etc.
+* `SignUpForm` - for signing up a new user. Encrypt passwords, send welcome emails, etc.
 * `SignInForm` - check that passwords match
 * `Admin{ModelName}Form` - sometimes admin can set more fields than a regular user. It’s
   often a good idea to extract a new form for those cases.


### PR DESCRIPTION
The welcome e and email e accidentally found themselves bound together.
Fixed for the English professor's sake (who may be reading these guides).