### PR TITLE
Adding in guide for Lucky Tasks

### DIFF
--- a/source/guides/asset-handling.html.md.erb
+++ b/source/guides/asset-handling.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Asset Handling
-order: 9
+order: 8
 intro: >
   Lucky handles JavaScript, CSS and image compilation for you out of the box.
   It also reloads the browser automatically when files change, making building

--- a/source/guides/tasks.html.md.erb
+++ b/source/guides/tasks.html.md.erb
@@ -1,0 +1,67 @@
+---
+title: Tasks in Lucky
+order: 9
+intro: >
+  Lucky uses Tasks to bundle up external operations you need for your application.
+  From seeding your database to printing an overview of all your routes and more.
+---
+
+## Overview
+
+Tasks are used to run some code that sits outside of your main application. When you need to add a task, you'll place it in the `tasks` folder. To see a list of the available tasks in your application, use `lucky --help`.
+
+To run a task, you just run 
+```
+lucky name.of.task [options]
+```
+
+## Built-in Tasks
+
+By default, Lucky has a few tasks already built in that you may find really handy while developing your application. These are the ones that you get by default.
+
+* `lucky db.create`       - Create the database
+* `lucky db.drop`         - Drop the database
+* `lucky db.migrate`      - Migrate the database
+* `lucky db.migrate.one`  - Run the next pending migration
+* `lucky db.redo`         - Rollback then run the last migration
+* `lucky db.rollback`     - Rollback the last migration
+* `lucky db.rollback_all` - Rollback all migrations
+* `lucky gen.action`      - Generate a new action
+* `lucky gen.migration`   - Generate a new migration
+* `lucky gen.model`       - Generate a model, query, and form
+* `lucky gen.secret_key`  - Generate a new secret key
+* `lucky routes`          - Show all the routes for the app
+* `lucky watch`           - Start and recompile project when files change
+
+## Custom Tasks
+
+Custom tasks you need will be placed in the `tasks` folder of your application. The two main things to creating a custom task is that your class inherits from `LuckyCli::Task`, and it implements a `call` method. Be sure to `require "lucky_cli"` at the top of your new task.
+
+Lucky will infer the name of the task by using the name of your class. This includes using namespaces. (e.g. `Db::Migrate` becomes `lucky db.migrate`).
+
+Additionally, you can add a `banner` at the top of your class to show a description of your task when the `--help` command is ran.
+
+```
+# tasks/generate_sitemaps.cr
+require "lucky_cli"
+class GenerateSitemaps < LuckCli::Task
+  banner "Generate the sitemap.xml for this site"
+
+  def call
+    # Implement your task here
+  end
+end
+```
+
+```
+$ lucky --help
+
+Usage: lucky name.of.task [options]
+
+Available tasks:
+
+  ...
+  ▸ generate_sitemaps Generate the sitemap.xml for this site
+  ...
+```
+

--- a/source/guides/tasks.html.md.erb
+++ b/source/guides/tasks.html.md.erb
@@ -2,13 +2,15 @@
 title: Tasks in Lucky
 order: 9
 intro: >
-  Lucky uses Tasks to bundle up external operations you need for your application.
+  Lucky uses Tasks to run one-off operations for your application.
   From seeding your database to printing an overview of all your routes and more.
 ---
 
 ## Overview
 
 Tasks are used to run some code that sits outside of your main application. When you need to add a task, you'll place it in the `tasks` folder. To see a list of the available tasks in your application, use `lucky --help`.
+
+You can think of a Luck Task just like a [Rake task](https://github.com/ruby/rake) in Ruby, [npm script](https://docs.npmjs.com/misc/scripts) for Node, or [Mix Task](https://hexdocs.pm/mix/Mix.Task.html) for Elixir.
 
 To run a task, you just run 
 ```
@@ -19,27 +21,28 @@ lucky name.of.task [options]
 
 By default, Lucky has a few tasks already built in that you may find really handy while developing your application. These are the ones that you get by default.
 
-* `lucky db.create`       - Create the database
-* `lucky db.drop`         - Drop the database
-* `lucky db.migrate`      - Migrate the database
-* `lucky db.migrate.one`  - Run the next pending migration
-* `lucky db.redo`         - Rollback then run the last migration
-* `lucky db.rollback`     - Rollback the last migration
-* `lucky db.rollback_all` - Rollback all migrations
-* `lucky gen.action`      - Generate a new action
-* `lucky gen.migration`   - Generate a new migration
-* `lucky gen.model`       - Generate a model, query, and form
-* `lucky gen.secret_key`  - Generate a new secret key
-* `lucky routes`          - Show all the routes for the app
-* `lucky watch`           - Start and recompile project when files change
+```
+# Generated with lucky --help
+lucky db.create       - Create the database
+lucky db.drop         - Drop the database
+lucky db.migrate      - Migrate the database
+lucky db.migrate.one  - Run the next pending migration
+lucky db.redo         - Rollback then run the last migration
+lucky db.rollback     - Rollback the last migration
+lucky db.rollback_all - Rollback all migrations
+lucky gen.action      - Generate a new action
+lucky gen.migration   - Generate a new migration
+lucky gen.model       - Generate a model, query, and form
+lucky gen.secret_key  - Generate a new secret key
+lucky routes          - Show all the routes for the app
+lucky watch           - Start and recompile project when files change
+```
 
 ## Custom Tasks
 
-Custom tasks you need will be placed in the `tasks` folder of your application. The two main things to creating a custom task is that your class inherits from `LuckyCli::Task`, and it implements a `call` method. Be sure to `require "lucky_cli"` at the top of your new task.
+Custom tasks you need will be placed in the `tasks` folder of your application. The three main things to creating a custom task is that your class inherits from `LuckyCli::Task`, it implements a `call` method, and includes a `banner`. Be sure to `require "lucky_cli"` at the top of your new task.
 
 Lucky will infer the name of the task by using the name of your class. This includes using namespaces. (e.g. `Db::Migrate` becomes `lucky db.migrate`).
-
-Additionally, you can add a `banner` at the top of your class to show a description of your task when the `--help` command is ran.
 
 ```
 # tasks/generate_sitemaps.cr


### PR DESCRIPTION
This PR adds in docs for the built-in tasks, as well as how to create custom tasks. I placed this below the assets page in the index ordering, but just above the writing JSON APIs. 