### PR TITLE
Remove note on asset dev/test fingerprinting

### DIFF
--- a/source/guides/asset-handling.html.md.erb
+++ b/source/guides/asset-handling.html.md.erb
@@ -119,9 +119,6 @@ asset changes, the fingerprint changes and the browser will use the new version.
 
 Make sure to use the `asset` macro to get fingerprinted assets.
 
-Note that fingerprints are only calculated in production. In dev and test there
-is no fingerprint.
-
 ## Deploying to production
 
 If you deploy to Heroku, then you won't need to do anything. Lucky is already


### PR DESCRIPTION
Fingerprinting is performed depending on setup of `webpack.mix.js`, which by default includes the `version()` regardless of environment.