### PR TITLE
Add links to laravel mix website + docs

### DIFF
--- a/source/guides/asset-handling.html.md.erb
+++ b/source/guides/asset-handling.html.md.erb
@@ -10,8 +10,8 @@ intro: >
 ## Asset handling with Webpack and Laravel Mix
 
 By default Lucky comes set up with asset handling using Webpack through
-Laravel Mix. Laravel Mix is a wrapper for common Webpack functionality that
-makes configuring Webpack much simpler.
+[Laravel Mix](https://www.npmjs.com/package/laravel-mix). Laravel Mix is a wrapper
+for common Webpack functionality that makes configuring Webpack much simpler.
 
 ## Why Laravel Mix instead of plain Webpack?
 
@@ -28,7 +28,8 @@ little configuration.
 There is a `webpack.mix.js` file in your project root. You can modify this to
 set up React, change your entry points, etc.
 
-Check out the Laravel Mix documentation for more examples of what you can do.
+Check out the [Laravel Mix documentation](https://github.com/JeffreyWay/laravel-mix/tree/master/docs#summary)
+for more examples of what you can do.
 
 ## Structuring your JavaScript
 


### PR DESCRIPTION
I opted not to link to https://laravel.com/docs/5.6/mix#introduction because that would confuse with the laravel tie ins even more I think.