### PR TITLE
Fix chromedriver installation instructions

### DIFF
--- a/source/guides/browser-tests.html.md.erb
+++ b/source/guides/browser-tests.html.md.erb
@@ -15,7 +15,7 @@ For tests to run you will need to install Chrome and Chromedriver:
 
 ### On macOS
 
-`brew install chromedriver`
+`brew cask install chromedriver`
 
 ### On Linux
 


### PR DESCRIPTION
Looks like `chromedriver` was migrated from homebrew/core to homebrew/cask.