### PR TITLE
Instructions for installing necessary dependencies on Fedora 28

### DIFF
--- a/source/guides/installing.html.md.erb
+++ b/source/guides/installing.html.md.erb
@@ -20,6 +20,7 @@ To get Lucky, you need to install these first.
 * [Crystal](https://crystal-lang.org/docs/installation/). Requires at least v0.25
 * Postgres ([macOS](https://postgresapp.com)/[Others](https://wiki.postgresql.org/wiki/Detailed_installation_guides))
 * Necessary libraries: On Debian (Ubuntu should be similar) run "apt-get install libc6-dev libevent-dev libpcre2-dev libpng-dev libssl1.0-dev libyaml-dev zlib1g-dev"
+* Necessary libraries on Fedora (28): run "dnf install glibc-devel libevent-devel pcre2-devel openssl-devel libyaml-devel zlib-devel libpng-devel". libpng-devel is for Laravel Mix
 
 ## Install Lucky
 


### PR DESCRIPTION
I've added the necessary libraries that I had to install for Lucky to work on Fedora 28. As of now, I didn't have any problems (I searched for the equivalents of the Debian/Ubuntu in Fedora, so it seems it is all good). If there is anything to change, let me know. :)