### PR TITLE
Make example for select consistent with other inputs

### DIFF
--- a/source/guides/saving-with-forms.html.md.erb
+++ b/source/guides/saving-with-forms.html.md.erb
@@ -222,8 +222,8 @@ checkbox f.admin, value: "true"
 
 ```
 # Assuming you have a form with a fillable category_id
-select_input form.category_id do
-  options_for_select(form.category_id, categories_for_select)
+select_input f.category_id do
+  options_for_select(f.category_id, categories_for_select)
 end
 
 private def categories_for_select


### PR DESCRIPTION
As I was copying this example, I realized that the variable for the form is always named `f` as shown in the other examples, not `form`. So I made this very tiny fix. My code compiles now with this corrected example.