### PR TITLE
Typo in querying the database guide

### DIFF
--- a/source/guides/querying-the-database.html.md.erb
+++ b/source/guides/querying-the-database.html.md.erb
@@ -69,9 +69,9 @@ For the model we defined Lucky would generate:
 * `age`
 * `name`
 
-                                 
+
 ## Distinct on
-                                 
+
 ```
 UserQuery.new.distinct_on(&.name)
 ```
@@ -161,17 +161,17 @@ UserQuery.new.find(id)
 # You can also chain methods before calling find, first, etc.
 UserQuery.new.age(30).find(1)
 ```
-  
+
 ## Ensuring no results are returned
-  
+
 ```
 UserQuery.new.none
 ```
-  
+
 This can be helpful when under certain conditions you want the resultd to be empty.
-  
+
 > This method does not return an empty array immediately. You can still chain other query methods, but it
-  will always return no records. For example: `UserQuery.new.none.first` will never return a result  
+  will always return no records. For example: `UserQuery.new.none.first` will never return a result
 
 ## Shorthand methods
 
@@ -259,7 +259,7 @@ require "./task"
 require "./company"
 
 class User < BaseModel
-  table users do
+  table :users do
     has_one supervisor : Supervisor
     has_many tasks : Task
     belongs_to company : Company


### PR DESCRIPTION
Also removing some extra white space that my editor stripped out.