### PR TITLE
document missing cookie/session deleted? method. 

### DIFF
--- a/source/guides/actions-and-routing.html.md.erb
+++ b/source/guides/actions-and-routing.html.md.erb
@@ -457,12 +457,14 @@ If you need to remove a session
 ```crystal
 # Delete a specific session key
 session.delete(:name)
+session.deleted?(:name) #=> true
 
 # Clear the current session
 session.clear
 
 # Delete a specific cookie
 cookies.delete("name")
+cookies.deleted?("person") #=> false
 
 # Delete all cookies
 cookies.clear

--- a/source/guides/actions-and-routing.html.md.erb
+++ b/source/guides/actions-and-routing.html.md.erb
@@ -450,9 +450,39 @@ cookies.set_raw("name", "Sally") # Sets a raw unencrypted cookie
 cookies.get_raw("name") # Will return "Sally"
 ```
 
+### Cookie Options
+
+The `cookies` helper method available to you in actions is an instance of `Lucky::CookieJar`. Sometimes you need to customize individual cookies by setting specific option values. There are many [cookie options](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie), and Lucky gives you a way to set these.
+
+```crystal
+# This gives you a HTTP::Cookie or raise an exception
+c_is_for_cookie = cookies.get_raw("cookiedough")
+
+# Set the name of the cookie to "cookie-dough"
+c_is_for_cookie.name("cookie-dough")
+
+# Set the value of cookie-dough to "yum"
+c_is_for_cookie.value("yum")
+
+# Set the path for the cookie to "/baking"
+c_is_for_cookie.path("/baking")
+
+# Set the expires date to tomorrow
+c_is_for_cookie.expires(1.day.from_now)
+
+# Set the domain to cookie.monst.er
+c_is_for_cookie.domain("cookie.monst.er")
+
+# Make the cookie secure
+c_is_for_cookie.secure(true)
+
+# Set the cookie to HTTP only
+c_is_for_cookie.http_only(true)
+```
+
 ### Clearing Sessions and Cookies
 
-If you need to remove a session
+If you need to remove a session or delete a cookie.
 
 ```crystal
 # Delete a specific session key


### PR DESCRIPTION
Fixes #125 

The other methods were already documented. Just added the missing `deleted?` method. I noticed there's some other methods in there that are pubic like `write(headers)`, and `update(cookies)`, but I'm not sure about those. If you want them documented, I can add that in too.