### PR TITLE
Update database-migrations.html.md.erb

### DIFF
--- a/source/guides/database-migrations.html.md.erb
+++ b/source/guides/database-migrations.html.md.erb
@@ -83,7 +83,7 @@ the end of the type to make the column optional (allow NULL)
   end
 
   def rollback
-     drop :things
+     drop :users
   end
 end
 ```


### PR DESCRIPTION
The initial migration creates a `:users` table, but the `rollback` method drops the `:things` table.